### PR TITLE
feat: pass subject_type from client config to create_session as sub_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ MongoDB is the storage, [here](https://github.com/italia/Satosa-Saml2Spid/tree/o
 
 `satosa.frontends.oidcop.storage.mongo.Mongodb` overloads them to have I/O operations on mongodb.
 
+##### Subject type #####
+
+The client configuration can also include the `subject_type` key, with permitted values being `public` and `pairwise`.  If absent, the default is to choose `public`.  This has been driven by backwards compatibility with existing behaviour: oidcop (`session_manager.create_session`) defaults to `public`.
+
+For user privacy, we strongly recommend selecting `pairwise` for new deployments, unless `public` is absolutely needed (for linking users across related but distinct services).
 
 ## Demo
 

--- a/satosa_oidcop/idpy_oidcop.py
+++ b/satosa_oidcop/idpy_oidcop.py
@@ -634,11 +634,14 @@ class OidcOpFrontend(FrontendModule, OidcOpEndpoints):
         _token_usage_rules = _ec.authn_broker.get_method_by_id("user")
 
         session_manager = _ec.session_manager
+        client = self.app.storage.get_client_by_id(client_id)
+        client_subject_type = client.get("subject_type", "public")
         _session_id = session_manager.create_session(
             authn_event=authn_event,
             auth_req=parse_req,
             user_id=sub,
             client_id=client_id,
+            sub_type=client_subject_type,
             token_usage_rules=_token_usage_rules,
         )
 


### PR DESCRIPTION
Fixes #21

If not set, default to `public` for backwards compatibility.

Btw, I see that elsewhere (in `_handle_authn_request`), `subject_type` defaults to `pairwise`

Happy to change the default to `pairwise` to match that if backwards compatibility with current deployments is not an issue.

Cheers,
Vlad