### PR TITLE
Get client_id for authorization_code lookup also from Basic auth

### DIFF
--- a/satosa_oidcop/core/storage/mongo.py
+++ b/satosa_oidcop/core/storage/mongo.py
@@ -125,7 +125,7 @@ class Mongodb(SatosaOidcStorage):
             # here for auth code flow and token endpoint only
             _q = {
                 "authorization_code": parse_req["code"],
-                "client_id": parse_req.get("client_id"),
+                "client_id": parse_req.get("client_id") or self.get_client_id_by_basic_auth(http_authz),
             }
         elif http_authz and not "Basic " in http_authz:
             # here for userinfo endpoint

--- a/satosa_oidcop/core/storage/mongo.py
+++ b/satosa_oidcop/core/storage/mongo.py
@@ -175,6 +175,17 @@ class Mongodb(SatosaOidcStorage):
             return
         self.client_db.insert_one(_client_data)
 
+    def get_client_id_by_basic_auth(self, request_authorization: str):
+        cred = base64.b64decode(
+            request_authorization.replace("Basic ", "").encode())
+        if not cred:
+            return
+
+        cred = cred.decode().split(":")
+        if len(cred) == 2:
+            client_id = cred[0]
+            return client_id
+
     def get_client_by_basic_auth(self, request_authorization: str):
         cred = base64.b64decode(
             request_authorization.replace("Basic ", "").encode())

--- a/satosa_oidcop/core/storage/mongo.py
+++ b/satosa_oidcop/core/storage/mongo.py
@@ -119,10 +119,7 @@ class Mongodb(SatosaOidcStorage):
         """
         data = {}
         _q = {}
-        http_authz = http_headers.get("headers", {}).get("authorization", {})
-        if "Basic " in http_authz:
-            # we want only bearer and dpop here!
-            http_authz = None
+        http_authz = http_headers.get("headers", {}).get("authorization", "")
 
         if parse_req.get("grant_type") == "authorization_code":
             # here for auth code flow and token endpoint only
@@ -130,8 +127,9 @@ class Mongodb(SatosaOidcStorage):
                 "authorization_code": parse_req["code"],
                 "client_id": parse_req.get("client_id"),
             }
-        elif http_authz:
+        elif http_authz and not "Basic " in http_authz:
             # here for userinfo endpoint
+            # exclude Basic auth: we want only bearer and dpop here!
             _q = {
                 "access_token": http_authz.replace("Bearer ", ""),
             }

--- a/satosa_oidcop/core/storage/mongo.py
+++ b/satosa_oidcop/core/storage/mongo.py
@@ -173,7 +173,7 @@ class Mongodb(SatosaOidcStorage):
             return
         self.client_db.insert_one(_client_data)
 
-    def get_client_id_by_basic_auth(self, request_authorization: str):
+    def get_client_creds_from_basic_auth(self, request_authorization: str):
         cred = base64.b64decode(
             request_authorization.replace("Basic ", "").encode())
         if not cred:
@@ -181,16 +181,18 @@ class Mongodb(SatosaOidcStorage):
 
         cred = cred.decode().split(":")
         if len(cred) == 2:
+            return cred
+
+    def get_client_id_by_basic_auth(self, request_authorization: str):
+        cred = self.get_client_creds_from_basic_auth(request_authorization)
+
+        if len(cred) == 2:
             client_id = cred[0]
             return client_id
 
     def get_client_by_basic_auth(self, request_authorization: str):
-        cred = base64.b64decode(
-            request_authorization.replace("Basic ", "").encode())
-        if not cred:
-            return
+        cred = self.get_client_creds_from_basic_auth(request_authorization)
 
-        cred = cred.decode().split(":")
         if len(cred) == 2:
             client_id = cred[0]
             client_secret = cred[1]

--- a/satosa_oidcop/core/storage/mongo.py
+++ b/satosa_oidcop/core/storage/mongo.py
@@ -127,7 +127,7 @@ class Mongodb(SatosaOidcStorage):
                 "authorization_code": parse_req["code"],
                 "client_id": parse_req.get("client_id") or self.get_client_id_by_basic_auth(http_authz),
             }
-        elif http_authz and not "Basic " in http_authz:
+        elif http_authz and "Basic " not in http_authz:
             # here for userinfo endpoint
             # exclude Basic auth: we want only bearer and dpop here!
             _q = {

--- a/tests/test_oidcop.py
+++ b/tests/test_oidcop.py
@@ -545,8 +545,7 @@ class TestOidcOpFrontend(object):
         context.request = {
             'grant_type': 'authorization_code',
             'redirect_uri': CLIENT_RED_URL,
-            # SKIP passing client_id as it is available in Basic auth passed in the request
-            # 'client_id': CLIENT_AUTHN_REQUEST['client_id'],
+            'client_id': CLIENT_AUTHN_REQUEST['client_id'],
             'state': CLIENT_AUTHN_REQUEST['state'],
             'code': resp["code"],
             # TODO
@@ -561,6 +560,26 @@ class TestOidcOpFrontend(object):
         # cleanup
         self.clean_inmemory(frontend)
 
+        token_resp = frontend.token_endpoint(context)
+        _token_resp = json.loads(token_resp.message)
+        assert _token_resp.get('access_token')
+        assert _token_resp.get('id_token')
+
+        # cleanup
+        self.clean_inmemory(frontend)
+
+        # Test Token endpoint without client ID
+        # start new authentication first
+        internal_response = self.setup_for_authn_response(context, frontend, authn_req)
+        http_resp = frontend.handle_authn_response(context, internal_response)
+        _res = urlparse(http_resp.message).query
+        resp = AuthorizationResponse().from_urlencoded(_res)
+        context.request = {
+            'grant_type': 'authorization_code',
+            'redirect_uri': CLIENT_RED_URL,
+            'state': CLIENT_AUTHN_REQUEST['state'],
+            'code': resp["code"],
+        }
         token_resp = frontend.token_endpoint(context)
         _token_resp = json.loads(token_resp.message)
         assert _token_resp.get('access_token')

--- a/tests/test_oidcop.py
+++ b/tests/test_oidcop.py
@@ -545,7 +545,8 @@ class TestOidcOpFrontend(object):
         context.request = {
             'grant_type': 'authorization_code',
             'redirect_uri': CLIENT_RED_URL,
-            'client_id': CLIENT_AUTHN_REQUEST['client_id'],
+            # SKIP passing client_id as it is available in Basic auth passed in the request
+            # 'client_id': CLIENT_AUTHN_REQUEST['client_id'],
             'state': CLIENT_AUTHN_REQUEST['state'],
             'code': resp["code"],
             # TODO


### PR DESCRIPTION
Support authorization_code lookup for clients with `client_secret_basic` authentication.

If client_id is not provided as a request param, get it from basic auth.

To make this possible:
* add method `get_client_id_by_basic_auth` - similar to existing `get_client_by_basic_auth`, but only parsing the basic auth and returning the `client_id` without fetching the client data from the database.
* expose `http_authz` as str also for Basic authentication.  Slightly restructure existing code to avoid having `http_authz` set to `None`, and also use  `""`, not `{}` as default value to make .replace work on the default value.

Fixes #20