### PR TITLE
fix: http code 403 instead of 200 when forbidden on userinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,13 @@ Each time a request is handled by an endpoint the oidcop session manager loads t
 
 #### Tests
 
-Before you run the tests mind that you've to start a local mongod instance.
+Before you run the tests mind that you've to start a local mongod instance, e.g. with:
+
+```
+docker run --rm -e ALLOW_EMPTY_PASSWORD=yes -e MONGODB_ENABLE_JOURNAL=false -p 27017:27017 --name mongodb bitnami/mongodb:latest
+```
+
+Then run the tests:
 
 ````
 pip install pytest

--- a/satosa_oidcop/idpy_oidcop.py
+++ b/satosa_oidcop/idpy_oidcop.py
@@ -386,9 +386,12 @@ class OidcOpEndpoints(OidcOpUtils):
 
         if isinstance(proc_req, JsonResponse):  # pragma: no cover
             return self.send_response(proc_req)
-        elif 'error' in proc_req:
+        elif 'error' in proc_req or 'error' in proc_req.get('response_args', {}):
             return self.send_response(
-                JsonResponse(proc_req.to_dict(), status="403")
+                JsonResponse(
+                    proc_req['response_args'] if 'response_args' in proc_req else proc_req.to_dict(),
+                    status="403"
+                )
             )
 
         # better return jwt or jwe here!


### PR DESCRIPTION
previously, a HTTP 200 Success response was returned when an invalid access token was used on userinfo

see https://github.com/IdentityPython/oidc-op/blob/29d6f35ab33b823b11040f460d6dd2d07f9a39ef/src/oidcop/oidc/userinfo.py#L152-L158