### PR TITLE
feat: handle prompt, acr and acr_values

### DIFF
--- a/satosa_oidcop/idpy_oidcop.py
+++ b/satosa_oidcop/idpy_oidcop.py
@@ -5,6 +5,7 @@ import base64
 import logging
 import os
 from urllib.parse import urlencode
+from datetime import datetime
 
 from cryptojwt.key_jar import KeyJar
 from idpyoidc.message.oauth2 import ResponseMessage
@@ -21,6 +22,12 @@ from idpyoidc.server.exception import UnAuthorizedClient
 from idpyoidc.server.exception import UnknownClient
 from idpyoidc.server.oidc.registration import random_client_id
 from satosa.context import Context
+try:
+    from satosa.context import add_prompt_to_context
+except ImportError:
+    # TODO: remove after https://github.com/IdentityPython/SATOSA/pull/419 is merged
+    def add_prompt_to_context(*args, **kwargs):
+        pass
 from satosa.frontends.base import FrontendModule
 from satosa.internal import InternalData
 import satosa.logging_util as lu
@@ -233,6 +240,18 @@ class OidcOpUtils(object):
         """
         if isinstance(parse_req, JsonResponse):
             return self.send_response(parse_req)
+
+        # do not handle prompt param by oidc-op, handle it here instead
+        prompt_arg = parse_req.pop("prompt", None)
+        if prompt_arg:
+            add_prompt_to_context(context, " ".join(prompt_arg) if isinstance(prompt_arg, list) else prompt_arg)
+
+        # save ACRs
+        acr_values = parse_req.pop("acr_values", None)
+        if acr_values:
+            acr_values = acr_values if isinstance(acr_values, list) else acr_values.split(" ")
+            context.decorate(Context.KEY_AUTHN_CONTEXT_CLASS_REF, acr_values)
+            context.state[Context.KEY_AUTHN_CONTEXT_CLASS_REF] = acr_values
 
         try:
             proc_req = endpoint.process_request(
@@ -712,9 +731,8 @@ class OidcOpFrontend(FrontendModule, OidcOpEndpoints):
         authn_event = create_authn_event(
             uid=sub,
             salt=base64.b64encode(os.urandom(self.app.salt_size)).decode(),
-            # TODO
-            # authn_info=auth_args['authn_class_ref'],
-            # authn_time=auth_args['iat']
+            authn_info=internal_resp.auth_info.auth_class_ref,
+            # TODO: authn_time=datetime.fromisoformat(internal_resp.auth_info.timestamp).timestamp(),
         )
 
         _ec = endpoint.upstream_get("context")


### PR DESCRIPTION
save prompt parameter in Context to be used by backends

(does not have to wait for https://github.com/IdentityPython/SATOSA/pull/419, it is backwards compatible)